### PR TITLE
Replace Contact Page with Email

### DIFF
--- a/htdocs/about_pg_body.php
+++ b/htdocs/about_pg_body.php
@@ -18,7 +18,7 @@
 
 		$ul_count = $team_members_count / 4;
 		$item_width = $pic_length + 6;
-		
+
 	    ?>
 		<?php for($i = 0; $i < $team_members_count;):?>
 			<?php
@@ -29,7 +29,7 @@
 			}
 			else {
 				$row_item_count = $team_members_count - $i;
-			}	
+			}
 
 			$row_width = $row_item_count * $item_width;
 			?>
@@ -53,24 +53,5 @@
 
 <div id="contact" class="bottom-info">
     <h2 class="pheader text-center">Contact Us</h2>
-    <?php
-        if(isset($_POST['contact_name']) && ($_POST['contact_body'])
-		&& isset($_POST['contact_email'])){
-		if (CMEmail::sendContactUsMsg($_POST['contact_name'], $_POST['contact_email'], $_POST['contact_body']))
-            		echo '<span class="label label-success">Thanks! Our team is looking forward to reading what you had to say!</span>';
-		else echo '<span class="label label-success">Sorry, your email didn\'t get sent. Try again later. We want to hear what you have to say!</span>';
-        }
-	else {
-		//echo '<span class="label label-success">Please fill out all fields.</span>';
-	}
-    ?>
-    <form method="post" action="" class="center-elem fullwidth">
-	<div style="float:left;">
-        <input placeholder="Name" type="text" required name="contact_name" class="input-half left" id="contact_name">
-        <input placeholder="Your Email" type="email" class="input-half right" id="contact_email" name="contact_email">
-	</div>
-	<div class="clear"></div>
-        <textarea class="center-elem full" placeholder="What do you have to say?" name="contact_body" id="contact_body" required></textarea>
-        <input type="submit" value="Send Message" class="btn cm-button center-elem">
-    </form>
+    <p class="text-center about-text">ken [at] culturemesh [dot] com</p>
 </div>

--- a/htdocs/templates/about.html
+++ b/htdocs/templates/about.html
@@ -33,20 +33,7 @@
 
 	<div id="contact" class="bottom-info mobile-widget bg-white">
 	    <h2 class="pheader text-center">Contact Us</h2>
-		{{# success }}
-            	<span class="label label-success">Thanks! Our team is looking forward to reading what you had to say!</span>
-		{{/ success }}
-		{{# failure }}
-		<span class="label label-success">Sorry, your email didn't get sent. Try again later. We want to hear what you have to say!</span>
-		{{/ failure }}
-	    <form method="post" action="" class="center-elem">
-		<div class="text-center">
-			<input id="contact_name" class="about-input input-half left dashboard cm-input-sm" placeholder="Name" type="text" required name="contact_name">
-			<input id="contact_email" class="about-input input-half right dashboard cm-input-sm" placeholder="Your Email" type="email" name="contact_email">
-			<textarea id="contact_body" class="about-input center-elem full dashboard cm-input-sm" placeholder="What do you have to say?" name="contact_body" required></textarea>
-			<input type="submit" value="Send Message" class="btn cm-button center-elem">
-		</div>
-	    </form>
+			<p class="text-center about-text">ken [at] culturemesh [dot] com</p>
 	</div>
 	{{/ content }}
 


### PR DESCRIPTION
Too much spam was coming through the contact form on the about page. To
prevent this, replace the form with an email address. Note that some of
the form code remains in `about.php`